### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -27,7 +27,7 @@ class action_plugin_xssnipper extends DokuWiki_Action_Plugin {
     /**
      * Register the eventhandlers
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array ());
     }
  

--- a/syntax.php
+++ b/syntax.php
@@ -44,7 +44,7 @@ class syntax_plugin_xssnipper extends DokuWiki_Syntax_Plugin {
 /******************************************************************************/
 /* handle the match
 */   
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ID;
         $match = substr($match,strlen('{(xssnipper>'),-2); //strip markup from start and end
 
@@ -96,7 +96,7 @@ class syntax_plugin_xssnipper extends DokuWiki_Syntax_Plugin {
 /* render output
 * @author Taggic <taggic@t-online.de>
 */   
-    function render($mode, &$renderer, $xssnipper) {
+    function render($mode, Doku_Renderer $renderer, $xssnipper) {
         global $ID;
         if(!$xssnipper['type'])  $xssnipper['type']='txt';
         if($this->_codeblock<1)  $this->_codeblock=1;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
